### PR TITLE
Fixed the sub-menu of about-us in the nav bar.

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -5,3 +5,27 @@
 .not-active{
     display: none;
 }
+
+.has-submenu .sub-menu {
+  display: block;
+  opacity: 0;
+  visibility: hidden;
+  position: absolute;
+  left: 0;
+  top: 100%;
+  background: #222;
+  min-width: 180px;
+  z-index: 1000;
+  padding: 0;
+  margin: 0;
+  border-radius: 0 0 8px 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  transition: opacity 0.25s 0.15s, visibility 0s 0.15s;
+}
+
+.has-submenu:hover .sub-menu,
+.has-submenu:focus-within .sub-menu {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.25s 0s, visibility 0s 0s;
+}


### PR DESCRIPTION
#### Fixes

<img width="534" alt="Screenshot 2025-07-01 at 11 51 45" src="https://github.com/user-attachments/assets/2ab67d2f-67ee-4ae1-b51d-1fc3909c569d" />

Previously, the sub-menu (drop-down) of the about-us section in the nav bar was a bit distorted and misaligned. 

Fixed this issue with proper css and alignment.

<img width="550" alt="Screenshot 2025-07-01 at 11 51 54" src="https://github.com/user-attachments/assets/20d25d37-b6d5-4bea-9c6c-f7719a9e528f" />
