### PR TITLE
Fixed: Feature card hover effects

### DIFF
--- a/src/components/Features/Features.css
+++ b/src/components/Features/Features.css
@@ -1,12 +1,13 @@
 .slide-2 {
-    max-height: 500px;
-    transition: max-height 0.8s ease-in-out;
+    max-height: 300px;
+    overflow: hidden;
+    transition: max-height 0.48s ease-in-out;
 }
 
 .content-hide-2 {
-    max-height: 0;
+    max-height: 0px;
     overflow: hidden;
-    transition: max-height 0.5s ease-out;
+    transition: max-height 0.3s ease-in-out;
 }
 
 .features-content{

--- a/src/css/template.css
+++ b/src/css/template.css
@@ -430,11 +430,13 @@ section.features .col-4 {
   background-color:#2D2D2D;
   color: #fff;
   padding: 40px;
+  transition: background-color 0.15s ease-in-out;
 }
 
 .features-content:hover {
-    background-color: #44aa70 ;
-    box-shadow: 0px 0px 30px rgba(0,0,0,0.5);
+  background-color: #44aa70 ;
+  box-shadow: 0px 0px 30px rgba(0,0,0,0.5);
+  transition: background-color 0.05s ease-out;
 }
 
 .features-content h4 {
@@ -1124,6 +1126,7 @@ section.video .left-content .main-button {
 }
 
 .video-item .video-caption h4 {
+    z-index: 10;
     font-size: 20px;
     text-transform: uppercase;
     font-weight: 700;


### PR DESCRIPTION
`Issue`: There was visual bug in hover effects
    - Content that should have been hidden in feature card was seen when hovered initially.
    - Hover transition was inconsistent (Leaving hover mid transition was too abrupt).
 
`Fixes`: 
    - The content was hidden until it could be shown (overflow was properly set).
    - Changed the max-height to appropriate value. so that transition time scales consistently with actual visual height.
    - Hover transition for background was added (Very subtle)

`Note`:
    - Issue/fix was in feature cards (to see them try hovering on the feature cards).
    - max-height was set to 300px, since all the feature cards height didn't exceed 250px.
    - I did notice there was a div that was hidden by default (probably will be used later), so max-height and animation time should be updated accordingly for smooth transition if those divs were to be used later. 

## Issue sample:
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/36d6ccc5-1b7c-4bf0-80f7-e8c110a299d6" />

## Fixed sample:
<img width="1916" height="1101" alt="image" src="https://github.com/user-attachments/assets/13ef10fb-92fc-44ec-8e16-66fe7b68febf" />
