### PR TITLE
Fix and Enhance: Play button near python logo

### DIFF
--- a/src/components/PastBootcamps/PastBootcamps.css
+++ b/src/components/PastBootcamps/PastBootcamps.css
@@ -65,11 +65,11 @@ section.video .left-content .main-button {
 .video-item figure .play {
   display: block;
   position: absolute;
-  bottom: 15px;
-  right: 15px;
+  bottom: 0px;
+  right: 0px;
   width: 60px;
   height: 60px;
-  z-index: 12;
+  z-index: 11;
 }
 .video-item figure img {
   display: block;
@@ -84,8 +84,10 @@ section.video .left-content .main-button {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  background-color: #44aa70 ;
+  background-color: #44aa70;
   pointer-events: none;
+  transition: background-color 0.15s ease-out,
+              scale 0.1s ease-out;
 }
 .video-item figure .play:after {
   content: '';
@@ -99,7 +101,10 @@ section.video .left-content .main-button {
   pointer-events: none;
 }
 .video-item figure .play:hover:before {
-  background-color: #2f7f55;
+  background-color: #2069E0;
+  scale: 1.05;
+  transition: background-color 0.2s ease-in,
+              scale 0.2s ease-in;
 }
 
 .video-item .video-caption {


### PR DESCRIPTION
Fixed overlap of play button with python logo and incorrect z-index, and added simple hover effects

**Changes made:**
1. Changed the position of play button to not overlap with logo
2. Changed the z-index of play button to 11 (it was 12 before).
3. Added a simple color change and subtle popout effect when hovered

**Reason for changes:**
1. When play button is hovered, the color changed darker and transparent which showed the background python logo.
2. When the webpage was scrolled to a certain amount the play button could be seen onto (above) navbar.
3. For making the play button more dynamic (it felt a bit static before).

**Relates to:** #28

**Type of Change:**
- Bugfix (Along with enhancement)

**Comparison for previous and new change:**

https://github.com/user-attachments/assets/06bcff4e-ec9b-4612-9187-eee6659eef20

**For previewing changes:** https://pdscofficial.your-mahendra.workers.dev/

**Note:** Navbar z-index is 12 and previous play button z-index was also 12 (so only decreased it to 11 as of now)